### PR TITLE
Enforce coverage level with GH action

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -37,6 +37,12 @@ jobs:
         go test -v -cover -race -coverprofile=coverage.txt -covermode=atomic
         go tool cover -html=coverage.txt -o coverage.html
 
+    - name: Ensure coverage level
+      run: |
+        target=70
+        cov=$(go tool cover -func=coverage.txt | sed -n -E 's/^total.*([[:digit:]][[:digit:]]\.[[:digit:]]+)\%/\1/p')
+        if (( $(echo "$cov < $target" | bc -l) )); then echo "Coverage ${cov}% below target of ${target}%"; exit 1; fi;
+
     - uses: actions/upload-artifact@v2
       with:
         name: coverage-report


### PR DESCRIPTION
Implement a simple coverage check as a GH action.

This is a stop gap until we get codecov.io working or the centralized TAM/OPs solution is in place.

The full coverage report along with a HTML visualization is alread uploaded as an artifact.