### PR TITLE
Do not push images for PRs

### DIFF
--- a/.github/workflows/docker-compose.yml
+++ b/.github/workflows/docker-compose.yml
@@ -6,8 +6,6 @@ name: Docker Build
 on:
   push:
     branches: [ master ]
-  pull_request:
-    branches: [ master ]
 
 jobs:
 


### PR DESCRIPTION
This is a quick fix to avoid pushing images for PRs that are yet to be merged, as it is happening for #14.