### PR TITLE
Only docker push on master

### DIFF
--- a/.github/workflows/docker-compose.yml
+++ b/.github/workflows/docker-compose.yml
@@ -20,8 +20,8 @@ jobs:
       
     - name: Login to Aether registry
       run: echo ${{ secrets.AETHER_DOCKER_REGISTRY_PASSWORD }} | docker login registry.aetherproject.org --username ${{ secrets.AETHER_DOCKER_REGISTRY_LOGIN }} --password-stdin
-      if: github.ref == 'refs/heads/main'
+      if: github.ref == 'refs/heads/master'
 
     - name: Push image to Aether registry
       run: docker push registry.aetherproject.org/tost/dbuf:latest
-      if: github.ref == 'refs/heads/main'
+      if: github.ref == 'refs/heads/master'


### PR DESCRIPTION
This PR disables the push step of the Docker workflow for PRs, as we don't want to publish images for unmerged changes.

Based on #16 