### PR TITLE
Place the resolved local UPD address in ModifyQueueRequests of client

### DIFF
--- a/cmd/dbuf-client/main.go
+++ b/cmd/dbuf-client/main.go
@@ -185,7 +185,8 @@ func (c *dbufClient) doModifyQueue(
 	_, err = c.ModifyQueue(
 		context.Background(),
 		&dbuf.ModifyQueueRequest{
-			Action: action, QueueId: uint64(queueId), DestinationAddress: *localDataplaneUrl,
+			Action: action, QueueId: uint64(queueId),
+			DestinationAddress: c.dataplaneConn.LocalAddr().String(),
 		},
 	)
 	if err != nil {


### PR DESCRIPTION
When `-local_dataplane_url` is not set or the port is missing, the client would send an incorrect destination address for the released packets. This is fixed by using the resolved/assigned address string from the connection.